### PR TITLE
Update to GNOME Runtime 45

### DIFF
--- a/com.github.rogercrocker.badabib.json
+++ b/com.github.rogercrocker.badabib.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.rogercrocker.badabib",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
     "command" : "badabib",
     "finish-args" : [


### PR DESCRIPTION
Since version 43 is now EOL.